### PR TITLE
104 [Fix] get_series, patch_series

### DIFF
--- a/routes/series.js
+++ b/routes/series.js
@@ -104,6 +104,7 @@ router.patch('/', (req, res) => {
 		for(var key in req.body) {
 			if (key != "id" && key != "keywords" && key != "uid") values[key] = req.body[key]
 		}
+		values["recent_update"] = new Date();
 		conn.query(sql, values, function(err, results) {
 			conn.release();
 			if(err) {

--- a/routes/series.js
+++ b/routes/series.js
@@ -34,8 +34,8 @@ router.get('/list/:option/:uid/:kid', (req, res) => {
 	})
 })
 
-router.get('/:sid', (req, res) => {
-	series.getSeriesData(res, req.params.sid, (series_data) => res.json(series_data));
+router.get('/:sid/:uid', (req, res) => {
+	series.getSeriesData(res, req.params.sid, req.params.uid, (series_data) => res.json(series_data));
 })
 
 router.post('/', (req, res) => {
@@ -70,13 +70,13 @@ router.post('/', (req, res) => {
 				})
 			}
 			else if (req.body.keywords.length == 0) 
-				series.getSeriesData(res, results.insertId, (series_data) => res.json(series_data));
+				series.getSeriesData(res, results.insertId, req.body.uid, (series_data) => res.json(series_data));
 			else {
 				var index = 0;
 				function addKeywordToSeriesCallback() {
 					index++;
 					if (index == req.body.keywords.length) 
-						series.getSeriesData(res, results.insertId, (series_data) => res.json(series_data));
+						series.getSeriesData(res, results.insertId, req.body.uid, (series_data) => res.json(series_data));
 					else keyword.addKeywordToSeries(res, results.insertId, req.body.keywords[index], addKeywordToSeriesCallback);
 				}
 				keyword.addKeywordToSeries(res, results.insertId, req.body.keywords[index], addKeywordToSeriesCallback);
@@ -90,6 +90,12 @@ router.patch('/', (req, res) => {
 		res.status(400).json({ 
 			error: "E005",
 			error_message: "수정할 시리즈의 id 정보가 누락됨."
+		})
+	}
+	if (req.body.uid == undefined) {
+		res.status(400).json({ 
+			error: "E005",
+			error_message: "uid 정보가 누락됨. (유저의 시리즈 찜꽁 여부 조회를 위해 uid가 필요.)"
 		})
 	}
 	app.getConnectionPool((conn) => {
@@ -113,7 +119,7 @@ router.patch('/', (req, res) => {
 				})
 			}
 			else if (req.body.keywords == null)
-				series.getSeriesData(res, req.body.id, (series_data) => res.json(series_data));
+				series.getSeriesData(res, req.body.id, req.body.uid, (series_data) => res.json(series_data));
 			else {
 				keyword.getSeriesKeyword(res, req.body.id, (keyword_list) => {
 					var index = 0;
@@ -129,7 +135,7 @@ router.patch('/', (req, res) => {
 					function deleteKeywordFromSeriesCallback() {
 						index++;
 						if (index == keyword_list.length) {
-							series.getSeriesData(res, req.body.id, (series_data) => res.json(series_data));
+							series.getSeriesData(res, req.body.id, req.body.uid, (series_data) => res.json(series_data));
 						}
 						else if (req.body.keywords.indexOf(keyword_list[index]) != -1) deleteKeywordFromSeriesCallback()
 						else keyword.deleteKeywordFromSeries(res, req.body.id, keyword_list[index], deleteKeywordFromSeriesCallback);

--- a/routes/series.js
+++ b/routes/series.js
@@ -102,7 +102,7 @@ router.patch('/', (req, res) => {
 		var sql = "update SERIES SET ? where id=" + req.body.id;
 		var values = {};
 		for(var key in req.body) {
-			if (key != "id" && key != "keywords") values[key] = req.body[key]
+			if (key != "id" && key != "keywords" && key != "uid") values[key] = req.body[key]
 		}
 		conn.query(sql, values, function(err, results) {
 			conn.release();

--- a/routes/series.js
+++ b/routes/series.js
@@ -107,6 +107,7 @@ router.patch('/', (req, res) => {
 		conn.query(sql, values, function(err, results) {
 			conn.release();
 			if(err) {
+				console.log(err);
 				res.status(400).json({
 				  error: "E002",
 				  error_message: "query 문법 오류"

--- a/routes/series.js
+++ b/routes/series.js
@@ -124,11 +124,11 @@ router.patch('/', (req, res) => {
 				series.getSeriesData(res, req.body.id, req.body.uid, (series_data) => res.json(series_data));
 			else {
 				keyword.getSeriesKeyword(res, req.body.id, (keyword_list) => {
-					var index = 0;
+					var index = -1;
 					function addKeywordToSeriesCallback() {
 						index++;
 						if (index == req.body.keywords.length) {
-							index = 0;
+							index = -1;
 							keyword.deleteKeywordFromSeries(res, req.body.id, keyword_list[index], deleteKeywordFromSeriesCallback);
 						}
 						else if (keyword_list.indexOf(req.body.keywords[index]) != -1) addKeywordToSeriesCallback()

--- a/utils/episode.js
+++ b/utils/episode.js
@@ -10,6 +10,7 @@ exports.getEpisodeList = (res, sid, callback) => {
 		conn.query(sql, function(err, episodes) {
 			conn.release();
 			if(err) {
+				console.log(err);
 				res.status(400).json({
 					error: "E002",
 					error_message: "query 문법 오류"

--- a/utils/keyword.js
+++ b/utils/keyword.js
@@ -50,6 +50,7 @@ exports.deleteKeywordFromSeries = (res, sid, kid, callback) => {
 		conn.query(sql, function(err, results) {
 			conn.release();
 			if(err) {
+				console.log(err);
 				res.status(400).json({
 				  error: "E002",
 				  error_message: "query 문법 오류"
@@ -66,6 +67,7 @@ exports.addKeywordToSeries = (res, sid, kid, callback) => {
 		conn.query(sql, function(err, keyword_list) {
 			conn.release();
 			if (err) {
+				console.log(err);
 				res.status(400).json({
 					error: "E002",
 					error_message: "query 문법 오류"

--- a/utils/keyword.js
+++ b/utils/keyword.js
@@ -34,6 +34,7 @@ function createNewRepresent (res, sid, kid, callback) {
 		conn.query(sql, function(err, results) {
 			conn.release();
 			if(err) {
+				console.log(err);
 				res.status(400).json({
 					error: "E002",
 					error_message: "query 문법 오류"
@@ -184,6 +185,7 @@ postKeyword = (res, keyword, callback) => {
 		conn.query(sql, function(err, results) {
 			conn.release();
 			if (err) {
+				console.log(err);
 				res.status(400).json({
 					error: "E002",
 					error_message: "query 문법 오류"

--- a/utils/keyword.js
+++ b/utils/keyword.js
@@ -11,6 +11,7 @@ exports.getSeriesKeyword = (res, sid, callback) => {
 		conn.query(sql, function(err, keyword_list) {
 			conn.release();
 			if(err) {
+				console.log(err);
 				res.status(400).json({
 					error: "E002",
 					error_message: "query 문법 오류"

--- a/utils/series.js
+++ b/utils/series.js
@@ -238,7 +238,7 @@ exports.makeResForSeriesList = (series_list, req, res, option) => {
 	}
 }
 
-exports.getSeriesData = (res, sid, callback) => {
+exports.getSeriesData = (res, sid, uid, callback) => {
 	app.getConnectionPool((conn) => {
 		var sql = "select * from SERIES where id=" + sid;
 		conn.query(sql, function(err, series_list) {
@@ -258,23 +258,26 @@ exports.getSeriesData = (res, sid, callback) => {
 			else {
 				user.getNickname(res, series_list[0]["uid"], (nickname) => {
 					keyword.getSeriesKeyword(res, sid, (keywords) => {
-						episode.getEpisodeList(res, sid, (episodes) => {
-							var result = {
-								sid: series_list[0]["id"],
-								title: series_list[0]["title"],
-								image: series_list[0]["image"],
-								introduction: series_list[0]["introduction"],
-								writer: nickname,
-								wid: series_list[0]["uid"],
-								zzimkkong: series_list[0]["zzimkkong"],
-								coin_num: series_list[0]["coin_num"],
-								coin_full_num: series_list[0]["coin_full_num"],
-								ad_days: series_list[0]["ad_days"],
-								keywords: keywords,
-								is_end: series_list[0]["is_end"],
-								episodes: episodes
-							}
-							callback(result);
+						user.getIs_zzimkkong(res, uid, sid, (is_zzimkkong) => {
+							episode.getEpisodeList(res, sid, (episodes) => {
+								var result = {
+									sid: series_list[0]["id"],
+									title: series_list[0]["title"],
+									image: series_list[0]["image"],
+									introduction: series_list[0]["introduction"],
+									writer: nickname,
+									wid: series_list[0]["uid"],
+									zzimkkong: series_list[0]["zzimkkong"],
+									coin_num: series_list[0]["coin_num"],
+									coin_full_num: series_list[0]["coin_full_num"],
+									ad_days: series_list[0]["ad_days"],
+									keywords: keywords,
+									is_zzimkkong: is_zzimkkong,
+									is_end: series_list[0]["is_end"],
+									episodes: episodes
+								}
+								callback(result);
+							});
 						});
 					});
 				});

--- a/utils/series.js
+++ b/utils/series.js
@@ -244,6 +244,7 @@ exports.getSeriesData = (res, sid, uid, callback) => {
 		conn.query(sql, function(err, series_list) {
 			conn.release();
 			if(err) {
+				console.log(err);
 				res.status(400).json({
 					error: "E002",
 					error_message: "query 문법 오류"

--- a/utils/user.js
+++ b/utils/user.js
@@ -8,6 +8,7 @@ exports.getNickname = (res, uid, callback) => {
 		conn.query(sql, function(err, users) {
 			conn.release();
 			if(err) {
+				console.log(err);
 				res.status(400).json({
 					error: "E002",
 					error_message: "query 문법 오류"
@@ -100,6 +101,7 @@ exports.getIs_zzimkkong = (res, uid, sid, callback) => {
 		conn.query(sql, function(err, zzimkkongs) {
 			conn.release();
 			if (err) {
+				console.log(err);
 				res.status(400).json({
 					error: "E002",
 					error_message: "query 문법 오류"


### PR DESCRIPTION
1. 시리즈 정보 조회시 ([GET] series/:sid/:uid) 유저가 해당 시리즈를 찜꽁했는지 여부를 위해 uid를 함께 받도록 변경
2. 시리즈 정보 수정([PATCH] series) 이후 수정된 정보를 리스폰스로 보낼 때도 찜꽁 여부를 함께 보내기 위해 req.body에 반드시 uid를 포함하도록 함. (uid를 같이 주지 않으면 에러 발생하게 함.)